### PR TITLE
issue/fix-cell-write-top-skip

### DIFF
--- a/TM1py/Services/CellService.py
+++ b/TM1py/Services/CellService.py
@@ -2217,10 +2217,11 @@ class CellService(ObjectService):
         url = "/api/v1/Cellsets('{cellset_id}')?$expand=" \
               "Cube($select=Name;$expand=Dimensions($select=Name))," \
               "Axes({filter_axis}$expand={hierarchies}Tuples($expand=Members({select_member_properties}" \
-              "{expand_elem_properties}{top_rows})))," \
+              "{expand_elem_properties}){top_rows}{skip_rows}))," \
               "Cells($select={cell_properties}{top_cells}{skip_cells}{filter_cells})" \
             .format(cellset_id=cellset_id,
-                    top_rows=f";$top={top}" if top and not skip else "",
+                    top_rows=f";$top={top}" if top else "",
+                    skip_rows=f";$skip={skip}" if skip else "",
                     cell_properties=",".join(cell_properties),
                     filter_axis=filter_axis,
                     hierarchies=expand_hierarchies,
@@ -2341,9 +2342,10 @@ class CellService(ObjectService):
         url = "/api/v1/Cellsets('{cellset_id}')?$expand=" \
               "Cube($select=Name;$expand=Dimensions($select=Name))," \
               "Axes({filter_axis}$expand={hierarchies}Tuples($expand=Members({select_member_properties}" \
-              "{expand_elem_properties}{top_rows})))" \
+              "{expand_elem_properties}){top_rows}{skip_rows}))" \
             .format(cellset_id=cellset_id,
-                    top_rows=f";$top={top}" if top and not skip else "",
+                    top_rows=f";$top={top}" if top else "",
+                    skip_rows=f";$skip={skip}" if skip else "",
                     filter_axis=filter_axis,
                     hierarchies=expand_hierarchies,
                     select_member_properties=select_member_properties,

--- a/TM1py/Utils/Utils.py
+++ b/TM1py/Utils/Utils.py
@@ -288,8 +288,6 @@ def build_content_from_cellset_dict(
 
     content_as_dict = CaseAndSpaceInsensitiveTuplesDict()
     for cell_ordinal, cell in enumerate(cells[:top or len(cells)]):
-        # if skip is used in execution we must use the original ordinal from the cell, if not we can simply enumerate
-        cell_ordinal = cell.get("Ordinal", cell_ordinal)
 
         coordinates = []
         for axis_ordinal, axis in enumerate(axes):


### PR DESCRIPTION
When using execute_mdx() with top=n with n smaller than the number of dimensions in the cube, the result showed only the first n columns (coordinates) instead of all columns and only n rows.
This pull request fixes this issue, and also improves the performance a bit by using skip in the Axis query as well, which leads to a smaller response.